### PR TITLE
Closes #10 Prevent pipeline hang during large cohort preprocessing

### DIFF
--- a/__run_src9/MinimumWaitingTime.java
+++ b/__run_src9/MinimumWaitingTime.java
@@ -1,0 +1,37 @@
+package com.thealgorithms.greedyalgorithms;
+
+import java.util.Arrays;
+
+/**
+ * The MinimumWaitingTime class provides a method to calculate the minimum
+ * waiting time for a list of queries using a greedy algorithm.
+ *
+ * @author Hardvan
+ */
+public final class MinimumWaitingTime {
+    private MinimumWaitingTime() {
+    }
+
+    /**
+     * Calculates the minimum waiting time for a list of queries.
+     * The function sorts the queries in non-decreasing order and then calculates
+     * the waiting time for each query based on its position in the sorted list.
+     *
+     * @param queries an array of integers representing the query times in picoseconds
+     * @return the minimum waiting time in picoseconds
+     */
+    public static int minimumWaitingTime(int[] queries) {
+        int n = queries.length;
+        if (n <= 1) {
+            return 0;
+        }
+
+        Arrays.sort(queries);
+
+        int totalWaitingTime = 0;
+        for (int i = 0; i < n; i++) {
+            totalWaitingTime += queries[i] * (n - i - 1);
+        }
+        return totalWaitingTime;
+    }
+}

--- a/__run_src9/monte_carlo_simulation.r
+++ b/__run_src9/monte_carlo_simulation.r
@@ -1,0 +1,31 @@
+# Required libraries
+library("quantmod")
+# Parameters
+S0 <- 100    # Initial stock price
+K <- 100     # Strike price
+r <- 0.05    # Risk-free rate
+sigma <- 0.2 # Volatility
+T <- 1       # Time to maturity (in years)
+n <- 252     # Number of trading days
+# Function to simulate stock prices using geometric Brownian motion
+simulate_stock_prices <- function(S0, r, sigma, T, n) {
+  dt <- T/n
+  t <- seq(0, T, by = dt)
+  W <- c(0, cumsum(sqrt(dt) * rnorm(n)))
+  S <- S0 * exp((r - 0.5 * sigma^2) * t + sigma * W)
+  return(S)
+}
+# Function to calculate option price using Monte Carlo simulation
+monte_carlo_option_price <- function(S0, K, r, sigma, T, n, num_simulations) {
+  option_prices <- numeric(num_simulations)
+  for (i in 1:num_simulations) {
+    ST <- simulate_stock_prices(S0, r, sigma, T, n)[n + 1] # Final stock price
+    option_prices[i] <- pmax(ST - K, 0) # Payoff of the option
+  }
+  option_price <- mean(option_prices) * exp(-r * T) # Discounted expected payoff
+  return(option_price)
+}
+# Number of Monte Carlo simulations
+num_simulations <- 10000
+option_price <- monte_carlo_option_price(S0, K, r, sigma, T, n, num_simulations)
+cat("Option price:", option_price, "\n")


### PR DESCRIPTION
10 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.